### PR TITLE
Issue #16: Fix Undefined function error in fivestar_views_api

### DIFF
--- a/fivestar.module
+++ b/fivestar.module
@@ -129,7 +129,7 @@ function fivestar_theme() {
 function fivestar_views_api() {
   return array(
     'api' => 3,
-    'path' => drupal_get_path('module', 'fivestar') . '/includes',
+    'path' => backdrop_get_path('module', 'fivestar') . '/includes',
   );
 }
 


### PR DESCRIPTION
Fixes issue #16 "Error: Call to undefined function drupal_get_path() in fivestar_views_api()" when Backdrop-Drupal compatibility is disabled.